### PR TITLE
A failing test for string bodies returning null instead of empty string

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -161,6 +161,15 @@ test("[func] xhr[method] get, put, post, patch", function(assert) {
     })
 })
 
+test("result is an empty string", function(assert) {
+    xhr.get({
+        uri: "/mock/200ok"
+    }, function(err, resp, body) {
+        assert.equal(body, '')
+        assert.end()
+    })
+})
+
 test("xhr[method] get, put, post, patch with url shorthands", function(assert) {
     var i = 0
     forEach(methods, function(method) {


### PR DESCRIPTION
This test fails in master, but passes in this branch of yours.  If you merge this pull request, the failing test will be added to https://github.com/Raynos/xhr/pull/126
